### PR TITLE
Add new tool: Whatweb

### DIFF
--- a/security-tools.json
+++ b/security-tools.json
@@ -491,6 +491,26 @@
         "mac",
         "windows"
       ]
+    },
+    {
+      "id": "whatweb",
+      "name": "Whatweb",
+      "description": "WhatWeb identifies websites. Its goal is to answer the question, \"What is that Website?\". WhatWeb recognises web technologies including content management systems (CMS), blogging platforms, statistic/analytics packages, JavaScript libraries, web servers, and embedded devices. WhatWeb has over 1800 plugins, each to recognise something different. WhatWeb also identifies version numbers, email addresses, account IDs, web framework modules, SQL errors, and more.",
+      "category": "reconnaissance",
+      "command": "whatweb target.com",
+      "url": "https://github.com/urbanadventurer/WhatWeb",
+      "documentation": "https://github.com/urbanadventurer/WhatWeb#whatweb---next-generation-web-scanner",
+      "tags": [
+        "scanner",
+        "technologies detector",
+        "osint"
+      ],
+      "difficulty": "beginner",
+      "platform": [
+        "linux",
+        "mac",
+        "windows"
+      ]
     }
   ]
 }


### PR DESCRIPTION
New tool submission:
        
Name: Whatweb
Description: WhatWeb identifies websites. Its goal is to answer the question, "What is that Website?". WhatWeb recognises web technologies including content management systems (CMS), blogging platforms, statistic/analytics packages, JavaScript libraries, web servers, and embedded devices. WhatWeb has over 1800 plugins, each to recognise something different. WhatWeb also identifies version numbers, email addresses, account IDs, web framework modules, SQL errors, and more.
Tags: scanner,technologies detector,osint
URL: https://github.com/urbanadventurer/WhatWeb