### PR TITLE
Add new one-liner

### DIFF
--- a/one-liners.json
+++ b/one-liners.json
@@ -360,5 +360,15 @@
       "unfurl"
     ],
     "createdAt": "2025-02-10T18:06:44.145Z"
+  },
+  {
+    "id": "oneliner-1739214146948",
+    "command": "bbrf inscope add '*.af.mil' '*.osd.mil' '*.marines.mil' '*.pentagon.mil' '*.disa.mil' '*.health.mil' '*.dau.mil' '*.dtra.mil' '*.ng.mil' '*.dds.mil' '*.uscg.mil' '*.army.mil' '*.dcma.mil' '*.dla.mil' '*.dtic.mil' '*.yellowribbon.mil' '*.socom.mil'",
+    "description": "The Bug Bounty Reconnaissance Framework (BBRF) can help you coordinate your reconnaissance workflows across multiple devices",
+    "category": "Reconnaissance",
+    "usedTools": [
+      "bbrf"
+    ],
+    "createdAt": "2025-02-10T19:02:26.948Z"
   }
 ]


### PR DESCRIPTION
New one-liner submission:

Command: `bbrf inscope add '*.af.mil' '*.osd.mil' '*.marines.mil' '*.pentagon.mil' '*.disa.mil' '*.health.mil' '*.dau.mil' '*.dtra.mil' '*.ng.mil' '*.dds.mil' '*.uscg.mil' '*.army.mil' '*.dcma.mil' '*.dla.mil' '*.dtic.mil' '*.yellowribbon.mil' '*.socom.mil'`
Description: The Bug Bounty Reconnaissance Framework (BBRF) can help you coordinate your reconnaissance workflows across multiple devices
Category: Reconnaissance
Used Tools: bbrf