### PR TITLE
Add new tool: hauditor 

### DIFF
--- a/security-tools.json
+++ b/security-tools.json
@@ -549,6 +549,25 @@
         "mac",
         "windows"
       ]
+    },
+    {
+      "id": "hauditor-",
+      "name": "hauditor ",
+      "description": "Hauditor is a tool designed to analyze the security headers returned by a web page and report dangerous configurations.",
+      "category": "reconnaissance",
+      "command": "hauditor -t example.com",
+      "url": "https://github.com/trap-bytes/hauditor",
+      "documentation": "https://github.com/trap-bytes/hauditor",
+      "tags": [
+        "headers",
+        "analyze"
+      ],
+      "difficulty": "beginner",
+      "platform": [
+        "mac",
+        "linux",
+        "windows"
+      ]
     }
   ]
 }


### PR DESCRIPTION
New tool submission:
        
Name: hauditor 
Description: Hauditor is a tool designed to analyze the security headers returned by a web page and report dangerous configurations.
Tags: headers,analyze
URL: https://github.com/trap-bytes/hauditor