### PR TITLE
Add new tool: csprecon

### DIFF
--- a/security-tools.json
+++ b/security-tools.json
@@ -549,6 +549,25 @@
         "mac",
         "windows"
       ]
+    },
+    {
+      "id": "csprecon",
+      "name": "csprecon",
+      "description": "Discover new target domains using Content Security Policy",
+      "category": "reconnaissance",
+      "command": "csprecon -u https://www.github.com",
+      "url": "https://github.com/edoardottt/csprecon",
+      "documentation": "https://github.com/edoardottt/csprecon",
+      "tags": [
+        "recon",
+        "subdomains"
+      ],
+      "difficulty": "beginner",
+      "platform": [
+        "linux",
+        "mac",
+        "windows"
+      ]
     }
   ]
 }


### PR DESCRIPTION
New tool submission:
        
Name: csprecon
Description: Discover new target domains using Content Security Policy
Tags: recon,subdomains
URL: https://github.com/edoardottt/csprecon